### PR TITLE
11056: Adding Staffing Vacancies for Allied Health Professionals and Non-Professionals to the Vacancies table

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/json/Root.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/json/Root.java
@@ -2026,6 +2026,7 @@ public class Root{
 	@JsonProperty("opEx_YTD_label-40")
 	public String opEx_YTD_label40;
 	public String benefit_value_rec_label;
+	
 	@JsonProperty("nursingNVP_sum1-1")
 	public String nursingNVP_sum11;
 	@JsonProperty("nursingNVP_item1-1")
@@ -2037,8 +2038,39 @@ public class Root{
 	@JsonProperty("nursingNVP_item1-4")
 	public String nursingNVP_item14;
 
-	// Updated fields 
+	@JsonProperty("alliedProfNVP_sum1-1")
+	public String alliedProfNVP_sum11;
+	@JsonProperty("alliedProfNVP_item1-1")
+	public String alliedProfNVP_item11;
+	@JsonProperty("alliedProfNVP_item1-2")
+	public String alliedProfNVP_item12;
+	@JsonProperty("alliedProfNVP_item1-3")
+	public String alliedProfNVP_item13;
+	@JsonProperty("alliedProfNVP_item1-4")
+	public String alliedProfNVP_item14;
+	@JsonProperty("alliedProfNVP_item1-5")
+	public String alliedProfNVP_item15;
+	@JsonProperty("alliedProfNVP_item1-6")
+	public String alliedProfNVP_item16;
+	@JsonProperty("alliedProfNVP_item1-7")
+	public String alliedProfNVP_item17;
 
+	@JsonProperty("alliedNPNVP_sum1-1")
+	public String alliedNPNVP_sum11;
+	@JsonProperty("alliedNPNVP_item1-1")
+	public String alliedNPNVP_item11;
+	@JsonProperty("alliedNPNVP_item1-2")
+	public String alliedNPNVP_item12;
+	@JsonProperty("alliedNPNVP_item1-3")
+	public String alliedNPNVP_item13;
+	@JsonProperty("alliedNPNVP_item1-4")
+	public String alliedNPNVP_item14;
+	@JsonProperty("alliedNPNVP_item1-5")
+	public String alliedNPNVP_item15;
+	@JsonProperty("alliedNPNVP_item1-6")
+	public String alliedNPNVP_item16;
+
+	// Updated fields 
 	public String compBNursing_calc1;
 	public String compBNursing_calc2;
 	public String compBNursing_calc3;
@@ -2978,6 +3010,96 @@ public class Root{
 	}
 	public void setNursingNVP_sum11(String nursingNVP_sum11) {
 		this.nursingNVP_sum11 = nursingNVP_sum11;
+	}
+	public String getAlliedProfNVP_sum11() {
+		return alliedProfNVP_sum11;
+	}
+	public void setAlliedProfNVP_sum11(String alliedProfNVP_sum11) {
+		this.alliedProfNVP_sum11 = alliedProfNVP_sum11;
+	}
+	public String getAlliedProfNVP_item11() {
+		return alliedProfNVP_item11;
+	}
+	public void setAlliedProfNVP_item11(String alliedProfNVP_item11) {
+		this.alliedProfNVP_item11 = alliedProfNVP_item11;
+	}
+	public String getAlliedProfNVP_item12() {
+		return alliedProfNVP_item12;
+	}
+	public void setAlliedProfNVP_item12(String alliedProfNVP_item12) {
+		this.alliedProfNVP_item12 = alliedProfNVP_item12;
+	}
+	public String getAlliedProfNVP_item13() {
+		return alliedProfNVP_item13;
+	}
+	public void setAlliedProfNVP_item13(String alliedProfNVP_item13) {
+		this.alliedProfNVP_item13 = alliedProfNVP_item13;
+	}
+	public String getAlliedProfNVP_item14() {
+		return alliedProfNVP_item14;
+	}
+	public void setAlliedProfNVP_item14(String alliedProfNVP_item14) {
+		this.alliedProfNVP_item14 = alliedProfNVP_item14;
+	}
+	public String getAlliedProfNVP_item15() {
+		return alliedProfNVP_item15;
+	}
+	public void setAlliedProfNVP_item15(String alliedProfNVP_item15) {
+		this.alliedProfNVP_item15 = alliedProfNVP_item15;
+	}
+	public String getAlliedProfNVP_item16() {
+		return alliedProfNVP_item16;
+	}
+	public void setAlliedProfNVP_item16(String alliedProfNVP_item16) {
+		this.alliedProfNVP_item16 = alliedProfNVP_item16;
+	}
+	public String getAlliedProfNVP_item17() {
+		return alliedProfNVP_item17;
+	}
+	public void setAlliedProfNVP_item17(String alliedProfNVP_item17) {
+		this.alliedProfNVP_item17 = alliedProfNVP_item17;
+	}
+	public String getAlliedNPNVP_sum11() {
+		return alliedNPNVP_sum11;
+	}
+	public void setAlliedNPNVP_sum11(String alliedNPNVP_sum11) {
+		this.alliedNPNVP_sum11 = alliedNPNVP_sum11;
+	}
+	public String getAlliedNPNVP_item11() {
+		return alliedNPNVP_item11;
+	}
+	public void setAlliedNPNVP_item11(String alliedNPNVP_item11) {
+		this.alliedNPNVP_item11 = alliedNPNVP_item11;
+	}
+	public String getAlliedNPNVP_item12() {
+		return alliedNPNVP_item12;
+	}
+	public void setAlliedNPNVP_item12(String alliedNPNVP_item12) {
+		this.alliedNPNVP_item12 = alliedNPNVP_item12;
+	}
+	public String getAlliedNPNVP_item13() {
+		return alliedNPNVP_item13;
+	}
+	public void setAlliedNPNVP_item13(String alliedNPNVP_item13) {
+		this.alliedNPNVP_item13 = alliedNPNVP_item13;
+	}
+	public String getAlliedNPNVP_item14() {
+		return alliedNPNVP_item14;
+	}
+	public void setAlliedNPNVP_item14(String alliedNPNVP_item14) {
+		this.alliedNPNVP_item14 = alliedNPNVP_item14;
+	}
+	public String getAlliedNPNVP_item15() {
+		return alliedNPNVP_item15;
+	}
+	public void setAlliedNPNVP_item15(String alliedNPNVP_item15) {
+		this.alliedNPNVP_item15 = alliedNPNVP_item15;
+	}
+	public String getAlliedNPNVP_item16() {
+		return alliedNPNVP_item16;
+	}
+	public void setAlliedNPNVP_item16(String alliedNPNVP_item16) {
+		this.alliedNPNVP_item16 = alliedNPNVP_item16;
 	}
 	public String getBenefit_value_rec_label() {
 		return benefit_value_rec_label;

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/processor/LtcQuarterlyYtdApiProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/processor/LtcQuarterlyYtdApiProcessor.java
@@ -1,7 +1,5 @@
 package ca.bc.gov.chefs.etl.forms.ltc.quarterly.processor;
 
-import java.util.Map;
-
 import ca.bc.gov.chefs.etl.constant.Constants;
 import ca.bc.gov.chefs.etl.core.processor.BaseApiProcessor;
 

--- a/src/main/java/ca/bc/gov/chefs/etl/util/CSVUtil.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/util/CSVUtil.java
@@ -22,7 +22,7 @@ import ca.bc.gov.chefs.etl.core.model.IModel;
 public class CSVUtil {
 
 	public static void main(String[] args) {
-			}
+	}
 
 	public static Map<String, List<List<String>>> provider(List<IModel> items) {
 		Map<String, List<List<String>>> map = new HashMap<>();
@@ -47,95 +47,101 @@ public class CSVUtil {
 		return map;
 	}
 
-	public static Map<String, List<List<String>>> removeAllNullKeys(Map<String, List<List<String>>> map){
+	public static Map<String, List<List<String>>> removeAllNullKeys(Map<String, List<List<String>>> map) {
 		Iterator<Map.Entry<String, List<List<String>>>> iterator = map.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, List<List<String>>> entry = iterator.next();
-            if (entry.getKey() == null) {
-                iterator.remove();
-            }
-        }
+		while (iterator.hasNext()) {
+			Map.Entry<String, List<List<String>>> entry = iterator.next();
+			if (entry.getKey() == null) {
+				iterator.remove();
+			}
+		}
 		return map;
-	}
-	
-	/**
-	 *  Replaces any found line breaks with a whitespace
-	 *  
-	 *  @deprecated
-	 *  This method isn't null safe and doesn't handle all possible characters.
-	 *  Use {@link CSVUtil#replaceCarriageReturnLineFeed(String)} instead.
-	 */
-	@Deprecated
-	public static String replaceLineBreaks(String data){
-		return data.replaceAll("\\R", " ");
-	}
-	
-	public static String replaceCarriageReturnLineFeed(String data) {
-	    if (StringUtils.isBlank(data)) {
-	        return data;
-	    }
-	    return data.replaceAll("\\r\\n|\\r|\\n", " ");
 	}
 
 	/**
-     *  Replaces any found line breaks with a whitespace
-     *  
-     *  @deprecated
-     *  This method swallows errors and doesn't handle all possible CHEFS formats.
-     *  Use {@link CSVUtil#formatDate(String)} instead.
-     */
-    @Deprecated
-	public static String getFormattedDate(String date) {
-	    if (StringUtils.isBlank(date)) {
-	        return date;
-	    }
-		try {
-//		String isoDate = date;
-//		SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-//		SimpleDateFormat targetFormat = new SimpleDateFormat("yyyyMMddHHmmss");
-//		String targetDate = targetFormat.format(isoFormat.parse(isoDate));
-//		System.out.println(targetDate);
-		
-    		String dateTimeString = date;
-            OffsetDateTime dateTime = OffsetDateTime.parse(dateTimeString);
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-            String formattedDateTime = dateTime.format(formatter);
-    		return formattedDateTime;
+	 * Replaces any found line breaks with a whitespace
+	 * 
+	 * @deprecated
+	 *             This method isn't null safe and doesn't handle all possible
+	 *             characters.
+	 *             Use {@link CSVUtil#replaceCarriageReturnLineFeed(String)}
+	 *             instead.
+	 */
+	@Deprecated
+	public static String replaceLineBreaks(String data) {
+		return data.replaceAll("\\R", " ");
+	}
+
+	public static String replaceCarriageReturnLineFeed(String data) {
+		if (StringUtils.isBlank(data)) {
+			return data;
 		}
-		catch(Exception e) {
+		return data.replaceAll("\\r\\n|\\r|\\n", " ");
+	}
+
+	/**
+	 * Replaces any found line breaks with a whitespace
+	 * 
+	 * @deprecated
+	 *             This method swallows errors and doesn't handle all possible CHEFS
+	 *             formats.
+	 *             Use {@link CSVUtil#formatDate(String)} instead.
+	 */
+	@Deprecated
+	public static String getFormattedDate(String date) {
+		if (StringUtils.isBlank(date)) {
+			return date;
+		}
+		try {
+			// String isoDate = date;
+			// SimpleDateFormat isoFormat = new
+			// SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+			// SimpleDateFormat targetFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+			// String targetDate = targetFormat.format(isoFormat.parse(isoDate));
+			// System.out.println(targetDate);
+			String dateTimeString = date;
+			// if dateTimeString is in the format '2024-03-31' convert to ISO
+			if (dateTimeString.length() == 10) {
+				dateTimeString = dateTimeString + "T12:00:00.000Z";
+			}
+			OffsetDateTime dateTime = OffsetDateTime.parse(dateTimeString);
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+			String formattedDateTime = dateTime.format(formatter);
+			return formattedDateTime;
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 		return null;
 	}
-	
-    public static String formatDate(String date) {
-        if (StringUtils.isBlank(date)) {
-            return date;
-        }
 
-        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-        // Handle dates without time component. E.g. 2018-10-25
-        if (date.length() == 10) {
-            LocalDateTime dateTime = LocalDate.parse(date).atTime(0, 0);
-            return dateTime.format(outputFormatter);
-        } else if (date.length() == 22) {
-           // Handle dates without time zone offset. E.g. 2024-06-30 12:00:00 AM
-            DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss a");
-            LocalDateTime dateTime = LocalDateTime.parse(date, inputFormatter);
-            return dateTime.format(outputFormatter);
-        } else {                
-            OffsetDateTime dateTime = OffsetDateTime.parse(date);
-            return dateTime.format(outputFormatter);
-        }
+	public static String formatDate(String date) {
+		if (StringUtils.isBlank(date)) {
+			return date;
+		}
 
-    }
-    
-    public static BigDecimal parseBigDecimal(String number) {
-        return StringUtils.isNotBlank(number) ? new BigDecimal(number) : BigDecimal.ZERO;
-    }
-    
-    public static String formatBigDecimal(BigDecimal decimal) {
-        return Objects.toString(decimal, "");
-    }
+		DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+		// Handle dates without time component. E.g. 2018-10-25
+		if (date.length() == 10) {
+			LocalDateTime dateTime = LocalDate.parse(date).atTime(0, 0);
+			return dateTime.format(outputFormatter);
+		} else if (date.length() == 22) {
+			// Handle dates without time zone offset. E.g. 2024-06-30 12:00:00 AM
+			DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss a");
+			LocalDateTime dateTime = LocalDateTime.parse(date, inputFormatter);
+			return dateTime.format(outputFormatter);
+		} else {
+			OffsetDateTime dateTime = OffsetDateTime.parse(date);
+			return dateTime.format(outputFormatter);
+		}
+
+	}
+
+	public static BigDecimal parseBigDecimal(String number) {
+		return StringUtils.isNotBlank(number) ? new BigDecimal(number) : BigDecimal.ZERO;
+	}
+
+	public static String formatBigDecimal(BigDecimal decimal) {
+		return Objects.toString(decimal, "");
+	}
 
 }


### PR DESCRIPTION
Description of changes:
- Added parsing logic for Allied Health Professionals and Non-Professionals Number of Vacant positions fields. These fields will now be added to the DIRECT_CARE_VACACIES table.
- Added Allied Health Professionals and Non-Professionals Number of Vacant positions fields to the JSON root and data models.
- Fixed Deprecated DateTime parsing logic.