### PR TITLE
HR Records fix for UAT load

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/hrRecords/processor/PcdHRRecordsApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/hrRecords/processor/PcdHRRecordsApiResponseProcessor.java
@@ -21,6 +21,7 @@ import ca.bc.gov.chefs.etl.forms.pcd.hrRecords.model.HRRecordsPractitioner;
 import ca.bc.gov.chefs.etl.forms.pcd.hrRecords.model.HRRecordsSubmission;
 import ca.bc.gov.chefs.etl.util.CSVUtil;
 import ca.bc.gov.chefs.etl.util.FileUtil;
+import ca.bc.gov.chefs.etl.util.JsonUtil;
 
 public class PcdHRRecordsApiResponseProcessor extends BaseApiResponseProcessor {
 	
@@ -32,7 +33,9 @@ public class PcdHRRecordsApiResponseProcessor extends BaseApiResponseProcessor {
         String payload = exchange.getIn().getBody(String.class);
         ObjectMapper mapper = new ObjectMapper();
 
-        List<Root> hrRecordsModels = mapper.readValue(payload, new TypeReference<List<Root>>() {
+        String fixedPayload = JsonUtil.fixPcnNameObject(payload);
+        
+        List<Root> hrRecordsModels = mapper.readValue(fixedPayload, new TypeReference<List<Root>>() {
         });
 
         List<HRRecordsSubmission> parsedhrRecords = parseHRRecordsRequest(hrRecordsModels);

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/hrRecords/processor/PcdHRRecordsApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/hrRecords/processor/PcdHRRecordsApiResponseProcessor.java
@@ -33,9 +33,9 @@ public class PcdHRRecordsApiResponseProcessor extends BaseApiResponseProcessor {
         String payload = exchange.getIn().getBody(String.class);
         ObjectMapper mapper = new ObjectMapper();
 
-        String fixedPayload = JsonUtil.fixPcnNameObject(payload);
+        payload = JsonUtil.fixPcnNameObject(payload);
         
-        List<Root> hrRecordsModels = mapper.readValue(fixedPayload, new TypeReference<List<Root>>() {
+        List<Root> hrRecordsModels = mapper.readValue(payload, new TypeReference<List<Root>>() {
         });
 
         List<HRRecordsSubmission> parsedhrRecords = parseHRRecordsRequest(hrRecordsModels);

--- a/src/main/java/ca/bc/gov/chefs/etl/util/JsonUtil.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/util/JsonUtil.java
@@ -133,6 +133,16 @@ public class JsonUtil {
         return result;
     }
 
+    public static String fixPcnNameObject(String payload) {
+        // The following code aims to replace occurrences of "pcnName":"{}" with "pcnName": "", as "pcnName" is
+        // expected to be a String and not an object
+        String pcnPattern = "\"pcnName\":\\{\\}";
+        String pcnReplacement = "\"pcnName\": \"\"";
+
+        String result = payload.replaceAll(pcnPattern, pcnReplacement);
+        return result;
+    }
+
     /**
      * Does some basic cleanup/conversion of common Unicode characters which aren't allowed in the
      * target ASCII database.

--- a/src/main/java/ca/bc/gov/chefs/etl/util/JsonUtil.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/util/JsonUtil.java
@@ -139,8 +139,7 @@ public class JsonUtil {
         String pcnPattern = "\"pcnName\":\\{\\}";
         String pcnReplacement = "\"pcnName\": \"\"";
 
-        String result = payload.replaceAll(pcnPattern, pcnReplacement);
-        return result;
+        return payload.replaceAll(pcnPattern, pcnReplacement);
     }
 
     /**


### PR DESCRIPTION
- Added fixPcnNameObject helper function to convert all "pcnName": {} into "pcnName": ""
- Applied helper function to the HR Records extracts