### PR TITLE
HI Data Load Remediation 1-16-2025 - CCMIS ID duplicate fix

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/json/Root.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/json/Root.java
@@ -1,11 +1,8 @@
 package ca.bc.gov.chefs.etl.forms.ltc.facility.json;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import ca.bc.gov.chefs.etl.core.json.Form;
-import ca.bc.gov.chefs.etl.core.model.IModel;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Root {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
@@ -2,7 +2,6 @@ package ca.bc.gov.chefs.etl.forms.ltc.facility.processor;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.Map;
 
 import org.apache.camel.Exchange;
@@ -48,6 +47,22 @@ public class FacilityInfoFormApiResponseProcessor implements Processor {
 		/* Mandatory fields */
 		List<FacilityInformation> facilityInfoParsed = new ArrayList<>();
 		for(Root facility : facilities) {
+
+			// TODO: Removal of duplicate submissions from business, and logic on CHEFS form to prevent duplicate submissions
+			// Check if the ccmisid is currently within the previous entries within facilityInfoParsed to remove duplications
+			boolean isDuplicate = false;
+			for (int i = facilityInfoParsed.size() - 1; i >= 0; i--) {
+				if (facilityInfoParsed.get(i).getCCIMSID().equals(facility.getCcimsid())) {
+					isDuplicate = true;
+					break;
+				}
+			}
+
+			// If the ccmisid is a duplicate, skip the current iteration
+			if(isDuplicate) {
+				continue;
+			}
+
 			FacilityInformation facilityInfo = new FacilityInformation();
 			facilityInfo.setAccreditationBody(facility.getFacilityAccreditationBody());
 			facilityInfo.setAccreditationDate(facility.getFacilityAccreditationDate());
@@ -78,6 +93,7 @@ public class FacilityInfoFormApiResponseProcessor implements Processor {
 			facilityInfo.setSubmissionStatus(facility.getForm().getStatus());
 
 			if(!facility.isTheOwnerTheSameAsTheOperator1()) {
+			facilityInfo.setOperatorAddress(facility.getOperatorAddress().getProperties().getFullAddress());
 			facilityInfo.setOperatorAddress(facility.getOperatorAddress().getProperties().getFullAddress());
 			facilityInfo.setOperatorCity(facility.getOperatorCity());
 			facilityInfo.setOperatorcontactemail(facility.getOperatorContactEmail());

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
@@ -50,12 +50,8 @@ public class FacilityInfoFormApiResponseProcessor implements Processor {
 
 			// TODO: Removal of duplicate submissions from business, and logic on CHEFS form to prevent duplicate submissions
 			// Check if the ccmisid is currently within the previous entries within facilityInfoParsed to remove duplications
-			boolean isDuplicate = facilityInfoParsed.stream().anyMatch(facilityInfo -> facilityInfo.getCCIMSID().equals(facility.getCcimsid()));
-
 			// If the ccmisid is a duplicate, skip the current iteration
-			if(isDuplicate) {
-				continue;
-			}
+			if (facilityInfoParsed.stream().anyMatch(facilityInfo -> facilityInfo.getCCIMSID().equals(facility.getCcimsid()))) continue;
 
 			FacilityInformation facilityInfo = new FacilityInformation();
 			facilityInfo.setAccreditationBody(facility.getFacilityAccreditationBody());

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
@@ -50,13 +50,7 @@ public class FacilityInfoFormApiResponseProcessor implements Processor {
 
 			// TODO: Removal of duplicate submissions from business, and logic on CHEFS form to prevent duplicate submissions
 			// Check if the ccmisid is currently within the previous entries within facilityInfoParsed to remove duplications
-			boolean isDuplicate = false;
-			for (int i = facilityInfoParsed.size() - 1; i >= 0; i--) {
-				if (facilityInfoParsed.get(i).getCCIMSID().equals(facility.getCcimsid())) {
-					isDuplicate = true;
-					break;
-				}
-			}
+			boolean isDuplicate = facilityInfoParsed.stream().anyMatch(facilityInfo -> facilityInfo.getCCIMSID().equals(facility.getCcimsid()));
 
 			// If the ccmisid is a duplicate, skip the current iteration
 			if(isDuplicate) {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/facility/processor/FacilityInfoFormApiResponseProcessor.java
@@ -94,7 +94,6 @@ public class FacilityInfoFormApiResponseProcessor implements Processor {
 
 			if(!facility.isTheOwnerTheSameAsTheOperator1()) {
 			facilityInfo.setOperatorAddress(facility.getOperatorAddress().getProperties().getFullAddress());
-			facilityInfo.setOperatorAddress(facility.getOperatorAddress().getProperties().getFullAddress());
 			facilityInfo.setOperatorCity(facility.getOperatorCity());
 			facilityInfo.setOperatorcontactemail(facility.getOperatorContactEmail());
 			facilityInfo.setOperatorcontactName(facility.getOperatorContactName());

--- a/src/main/java/ca/bc/gov/chefs/etl/util/JsonUtil.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/util/JsonUtil.java
@@ -117,10 +117,10 @@ public class JsonUtil {
         String replacementOwnerAddress =
                 "\"ownerAddress\": {\"geometry\": {\"coordinates\": [0, 0]}, \"properties\": {\"fullAddress\": \"$1\"}}";
         String regexOperatorAddress = "\"operatorAddress\":\\s*\"([^\"]*)\"";
-        String replacementOperatotAddress =
+        String replacementOperatorAddress =
                 "\"operatorAddress\": {\"geometry\": {\"coordinates\": [0, 0]}, \"properties\": {\"fullAddress\": \"$1\"}}";
         return payload.replaceAll(regexOwnerAddress, replacementOwnerAddress)
-                .replaceAll(regexOperatorAddress, replacementOperatotAddress);
+                .replaceAll(regexOperatorAddress, replacementOperatorAddress);
     }
 
     public static String fixPcnName(String payload) {


### PR DESCRIPTION
- Added logic to anyMatch output list for items with the same ID and skip the current iteration if that is the case.
- Removed unneeded exports.
- Fixed typo on past data handler function.