### PR TITLE
Updating OpenShift deployments to reflect current state

### DIFF
--- a/openshift/app.cm.yaml
+++ b/openshift/app.cm.yaml
@@ -20,6 +20,19 @@ objects:
     data:
       hi-pub-key: |
         ${PUBLIC_KEY}
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: medis-etl-config
+    immutable: false
+    data:
+      log4j2.properties: |-
+        appender.out.type = Console
+        appender.out.name = out
+        appender.out.layout.type = PatternLayout
+        appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+        rootLogger.level = INFO
+        rootLogger.appenderRef.out.ref = out
 parameters:
   - name: APP_NAME
     description: Application name

--- a/openshift/app.cm.yaml
+++ b/openshift/app.cm.yaml
@@ -12,37 +12,14 @@ labels:
 metadata:
   name: "${REPO_NAME}-app-cm"
 objects:
-  - apiVersion: v1
-    kind: ConfigMap
+  - kind: ConfigMap
+    apiVersion: v1
     metadata:
-      name: medis-etl-config
-    data:
-      application.properties: |
-        # properties used in route
-        hostname = localhost
-        port = 8080
-
-        chefs.http.uri=https://submit.digital.gov.bc.ca/app/api/v1/forms/%s/export?format=json&type=submissions&minDate=%s&maxDate=%s
-
-        aims.username=2f173b2b-2f3a-407a-aecf-6b4bdc9431ae
-        aims.password=tbd
-
-        ltc.facility.username=e1f4761f-efdd-4529-805e-677d3ae21601
-        ltc.facility.password=tbd
-
-        ltc.staffing.username=16ce36ca-9b4b-4ec6-bb75-96c2e1f258bb
-        ltc.staffing.password=tbd
-
-        ltc.ytd.username=256760e7-6e8b-44c4-8b63-51fb72c8c2cf
-        ltc.ytd.password=tbd
-      log4j2.properties: |
-        appender.out.type = Console
-        appender.out.name = out
-        appender.out.layout.type = PatternLayout
-        appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
-        rootLogger.level = INFO
-        rootLogger.appenderRef.out.ref = out
+      name: medis-etl-encryption
     immutable: false
+    data:
+      hi-pub-key: |
+        ${PUBLIC_KEY}
 parameters:
   - name: APP_NAME
     description: Application name
@@ -55,4 +32,8 @@ parameters:
   - name: REPO_NAME
     description: Application repository name
     displayName: Repository Name
+    required: true
+  - name: PUBLIC_KEY
+    description: Public key for encryption
+    displayName: Public key
     required: true

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -66,7 +66,7 @@ objects:
             - mountPath: ${DATA_DIR}
               name: medis-etl-files
             - mountPath: ${APP_CONFIG_DIR}
-              name: medis-etl-config
+              name: medis-etl-secrets
             - mountPath: /ssh
               name: medis-etl-ssh
               readOnly: true
@@ -79,9 +79,10 @@ objects:
           - name: medis-etl-files
             persistentVolumeClaim:
               claimName: medis-etl-pvc
-          - name: medis-etl-config
-            configMap:
-              name: medis-etl-config
+          - name: medis-etl-secrets
+            secret:
+              secretName: medis-etl-secrets
+              defaultMode: 420
           - name: medis-etl-ssh
             secret:
               defaultMode: 400

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -66,7 +66,7 @@ objects:
             - mountPath: ${DATA_DIR}
               name: medis-etl-files
             - mountPath: ${APP_CONFIG_DIR}
-              name: medis-etl-secrets
+              name: medis-etl-config
             - mountPath: /ssh
               name: medis-etl-ssh
               readOnly: true
@@ -79,9 +79,13 @@ objects:
           - name: medis-etl-files
             persistentVolumeClaim:
               claimName: medis-etl-pvc
-          - name: medis-etl-secrets
-            secret:
-              secretName: medis-etl-secrets
+          - name: medis-etl-config
+            projected:
+              sources:
+                - secret:
+                    name: medis-etl-secrets
+                - configMap:
+                    name: medis-etl-config
               defaultMode: 420
           - name: medis-etl-ssh
             secret:

--- a/openshift/app.secret.yaml
+++ b/openshift/app.secret.yaml
@@ -49,13 +49,6 @@ objects:
 
         ltc.ytd.username=256760e7-6e8b-44c4-8b63-51fb72c8c2cf
         ltc.ytd.password=tbd
-      log4j2.properties: |
-        appender.out.type = Console
-        appender.out.name = out
-        appender.out.layout.type = PatternLayout
-        appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
-        rootLogger.level = INFO
-        rootLogger.appenderRef.out.ref = out
 parameters:
   - name: TOKEN
     description: The token used to in the URL of Webhook.

--- a/openshift/app.secret.yaml
+++ b/openshift/app.secret.yaml
@@ -26,6 +26,36 @@ objects:
       name: "medis-etl-github-webhook-secret"
     data:
       WebHookSecretKey: "${TOKEN}"
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: medis-etl-secrets
+    data:
+      application.properties: |
+        # properties used in route
+        hostname = localhost
+        port = 8080
+
+        chefs.http.uri=https://submit.digital.gov.bc.ca/app/api/v1/forms/%s/export?format=json&type=submissions&minDate=%s&maxDate=%s
+
+        aims.username=2f173b2b-2f3a-407a-aecf-6b4bdc9431ae
+        aims.password=tbd
+
+        ltc.facility.username=e1f4761f-efdd-4529-805e-677d3ae21601
+        ltc.facility.password=tbd
+
+        ltc.staffing.username=16ce36ca-9b4b-4ec6-bb75-96c2e1f258bb
+        ltc.staffing.password=tbd
+
+        ltc.ytd.username=256760e7-6e8b-44c4-8b63-51fb72c8c2cf
+        ltc.ytd.password=tbd
+      log4j2.properties: |
+        appender.out.type = Console
+        appender.out.name = out
+        appender.out.layout.type = PatternLayout
+        appender.out.layout.pattern = [%30.30t] %-30.30c{1} %-5p %m%n
+        rootLogger.level = INFO
+        rootLogger.appenderRef.out.ref = out
 parameters:
   - name: TOKEN
     description: The token used to in the URL of Webhook.


### PR DESCRIPTION
- Moving application.properties to medis-etl-secrets since this ConfigMap now contains form API keys
- Adding new ConfigMap that contains Public Key for encryption
- Updating DeploymentConfig to refer to the new secret