### PR TITLE
Updating Memory limits from 1Gi to 2Gi

### DIFF
--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -59,7 +59,7 @@ objects:
               protocol: TCP
             resources:
               limits:
-                memory: 1Gi
+                memory: 2Gi
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
             volumeMounts:


### PR DESCRIPTION
- Updating Memory limits from 1Gi to 2Gi for deployments to match current values