### PR TITLE
PCD failed load 5-14-2025: Setting default for lateEntry on UPCC Budget form

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/constant/PCDConstants.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/constant/PCDConstants.java
@@ -29,6 +29,7 @@ public class PCDConstants extends Constants {
 	public static final String HA_MAPPING_TYPE_NPPCC = "NPPCC";
 	public static final String HA_MAPPING_TYPE_PCN_COMMUNITY = "PCN Community";
 	public static final String HA_MAPPING_TYPE_UPCC = "UPCC";
+	public static final String DEFAULT_BOOLEAN_FALSE = "false";
 
 	/**
 	 * Decision Log Form

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/upcc/budget/model/FinancialBudgetUPCC.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/upcc/budget/model/FinancialBudgetUPCC.java
@@ -3,6 +3,8 @@ package ca.bc.gov.chefs.etl.forms.pcd.upcc.budget.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -46,7 +48,7 @@ public class FinancialBudgetUPCC  implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {


### PR DESCRIPTION
- Add new constant for "false"
- Add new constant as a default value for lateEntry in UPCC Budget route