### PR TITLE
Adding a default for all PCD routes for lateEntry

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/chc/financialReporting/model/FinancialReportingChcSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/chc/financialReporting/model/FinancialReportingChcSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.chc.financialReporting.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 import ca.bc.gov.chefs.etl.util.CSVUtil;
@@ -52,7 +52,7 @@ public class FinancialReportingChcSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/chc/pcPatientServices/model/PCPSChcSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/chc/pcPatientServices/model/PCPSChcSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.chc.pcPatientServices.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -62,7 +62,7 @@ public class PCPSChcSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/decisionLog/model/DecisionLogSubmissions.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/decisionLog/model/DecisionLogSubmissions.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.decisionLog.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -118,7 +118,7 @@ public class DecisionLogSubmissions implements IModel {
 	}
 
 	public void setLateEntry(String lateEntry) {
-		this.lateEntry = lateEntry;
+		this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
 	}
 
 	public String getHealthAuthority() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/financialExpenseHierarchy/model/ExpenseHierarchySubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/financialExpenseHierarchy/model/ExpenseHierarchySubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.financialExpenseHierarchy.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -44,7 +44,7 @@ public class ExpenseHierarchySubmission implements IModel{
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/fiscalYearReportingDates/model/FiscalYearReportingDatesSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/fiscalYearReportingDates/model/FiscalYearReportingDatesSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.fiscalYearReportingDates.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -43,7 +43,7 @@ public class FiscalYearReportingDatesSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/haHierarchy/model/HealthAuthority.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/haHierarchy/model/HealthAuthority.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.haHierarchy.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -107,7 +107,7 @@ public class HealthAuthority implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getHealthAuthorityCode() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/hrRecords/model/HRRecordsSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/hrRecords/model/HRRecordsSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.hrRecords.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -42,7 +42,7 @@ public class HRRecordsSubmission implements IModel{
         return lateEntry;
     }
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
     public String getSubmitterFullName() {
         return submitterFullName;

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/nppcc/financialReporting/model/FinancialReportingNppccSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/nppcc/financialReporting/model/FinancialReportingNppccSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.nppcc.financialReporting.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 import ca.bc.gov.chefs.etl.util.CSVUtil;
@@ -52,7 +52,7 @@ public class FinancialReportingNppccSubmission implements IModel {
 	}
 
 	public void setLateEntry(String lateEntry) {
-		this.lateEntry = lateEntry;
+		this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
 	}
 
 	public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/pcn/financialReporting/model/FRPcnSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/pcn/financialReporting/model/FRPcnSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.pcn.financialReporting.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 import ca.bc.gov.chefs.etl.util.CSVUtil;
@@ -51,7 +51,7 @@ public class FRPcnSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/practitionerRoleMapping/model/PractitionerRoleMappingSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/practitionerRoleMapping/model/PractitionerRoleMappingSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.practitionerRoleMapping.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -34,7 +34,7 @@ public class PractitionerRoleMappingSubmission implements IModel {
         return lateEntry;
     }
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
     public String getSubmitterFullName() {
         return submitterFullName;

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/provincialRiskTracking/model/ProvincialRiskTracking.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/provincialRiskTracking/model/ProvincialRiskTracking.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.provincialRiskTracking.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 import ca.bc.gov.chefs.etl.util.CSVUtil;
@@ -50,7 +50,7 @@ public class ProvincialRiskTracking implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/statusTracker/model/StatusTrackerSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/statusTracker/model/StatusTrackerSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.statusTracker.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -68,7 +68,7 @@ public class StatusTrackerSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/upcc/financialReporting/model/FinancialReportingUpccSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/upcc/financialReporting/model/FinancialReportingUpccSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.upcc.financialReporting.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 import ca.bc.gov.chefs.etl.util.CSVUtil;
@@ -52,7 +52,7 @@ public class FinancialReportingUpccSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/upcc/pcPatientServices/model/PCPSUpccSubmission.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/pcd/upcc/pcPatientServices/model/PCPSUpccSubmission.java
@@ -2,7 +2,7 @@ package ca.bc.gov.chefs.etl.forms.pcd.upcc.pcPatientServices.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.apache.commons.lang3.StringUtils;
 import ca.bc.gov.chefs.etl.constant.PCDConstants;
 import ca.bc.gov.chefs.etl.core.model.IModel;
 
@@ -62,7 +62,7 @@ public class PCPSUpccSubmission implements IModel {
     }
 
     public void setLateEntry(String lateEntry) {
-        this.lateEntry = lateEntry;
+        this.lateEntry = StringUtils.defaultIfEmpty(lateEntry, PCDConstants.DEFAULT_BOOLEAN_FALSE);
     }
 
     public String getSubmitterFullName() {


### PR DESCRIPTION
- lateEntry is null for all submissions by bulk upload, setting default on ETL to not fail HealthIdeas.