### PR TITLE
Adding YTD backwards compatibility to annual budget

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/budget/processor/LtcAnnualBudgetApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/budget/processor/LtcAnnualBudgetApiResponseProcessor.java
@@ -49,6 +49,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 		payload = JsonUtil.preProcess(payload);
 		payload = JsonUtil.fixUnicodeCharacters(payload);
 		payload = JsonUtil.roundDigitsNumber(payload);
+		payload = JsonUtil.ltcYTDBackwardCompatibility(payload);
 		ObjectMapper mapper = new ObjectMapper();
 		List<Root> ltcBudgetForms = mapper.readValue(payload, new TypeReference<List<Root>>() {
 		});


### PR DESCRIPTION
Annual Budget contains a similar set of fields to QYTD that also has been out of sync with ETL.