### PR TITLE
BCMOHAM-29035: resolving duplicate data issues pointed out by business area

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/budget/processor/LtcAnnualBudgetApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/budget/processor/LtcAnnualBudgetApiResponseProcessor.java
@@ -685,7 +685,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 			alliedNPRTProfC.setDirCareCostProdHrsOrientationBudget(root.getAlliedNPProdC_item31());
 			alliedNPRTProfC.setDirCareCostProdHrsContractedBudget(root.getAlliedNPProdCCS1());
 			alliedNPRTProfC.setDirCareCostNonProdHrsVacBudget(root.getAlliedNPNProdC_item11());
-			alliedNPRTProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPProdC_item21());
+			alliedNPRTProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPNProdC_item21());
 			alliedNPRTProfC.setDirCareCostNonProdHrsOtherBudget(root.getAlliedNPNProdC_item31());
 			alliedNPRTProfC.setConfirmationId(root.getForm().getConfirmationId());
 			alliedNPRTProfC.setDirCareCostType(root.getAlliedNP_label());
@@ -704,7 +704,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 			alliedNPRAProfC.setDirCareCostProdHrsOrientationBudget(root.getAlliedNPProdC_item32());
 			alliedNPRAProfC.setDirCareCostProdHrsContractedBudget(root.getAlliedNPProdCCS2());
 			alliedNPRAProfC.setDirCareCostNonProdHrsVacBudget(root.getAlliedNPNProdC_item12());
-			alliedNPRAProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPProdC_item22());
+			alliedNPRAProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPNProdC_item22());
 			alliedNPRAProfC.setDirCareCostNonProdHrsOtherBudget(root.getAlliedNPNProdC_item32());
 			alliedNPRAProfC.setConfirmationId(root.getForm().getConfirmationId());
 			alliedNPRAProfC.setDirCareCostType(root.getAlliedNP_label());
@@ -724,7 +724,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 			alliedNPAWProfC.setDirCareCostProdHrsOrientationBudget(root.getAlliedNPProdC_item33());
 			alliedNPAWProfC.setDirCareCostProdHrsContractedBudget(root.getAlliedNPProdCCS3());
 			alliedNPAWProfC.setDirCareCostNonProdHrsVacBudget(root.getAlliedNPNProdC_item13());
-			alliedNPAWProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPProdC_item23());
+			alliedNPAWProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPNProdC_item23());
 			alliedNPAWProfC.setDirCareCostNonProdHrsOtherBudget(root.getAlliedNPNProdC_item33());
 			alliedNPAWProfC.setConfirmationId(root.getForm().getConfirmationId());
 			alliedNPAWProfC.setDirCareCostType(root.getAlliedNP_label());
@@ -744,7 +744,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 			alliedNPMTProfC.setDirCareCostProdHrsOrientationBudget(root.getAlliedNPProdC_item34());
 			alliedNPMTProfC.setDirCareCostProdHrsContractedBudget(root.getAlliedNPProdCCS4());
 			alliedNPMTProfC.setDirCareCostNonProdHrsVacBudget(root.getAlliedNPNProdC_item14());
-			alliedNPMTProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPProdC_item24());
+			alliedNPMTProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPNProdC_item24());
 			alliedNPMTProfC.setDirCareCostNonProdHrsOtherBudget(root.getAlliedNPNProdC_item34());
 			alliedNPMTProfC.setConfirmationId(root.getForm().getConfirmationId());
 			alliedNPMTProfC.setDirCareCostType(root.getAlliedNP_label());
@@ -764,7 +764,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 			alliedNPATProfC.setDirCareCostProdHrsOrientationBudget(root.getAlliedNPProdC_item35());
 			alliedNPATProfC.setDirCareCostProdHrsContractedBudget(root.getAlliedNPProdCCS5());
 			alliedNPATProfC.setDirCareCostNonProdHrsVacBudget(root.getAlliedNPNProdC_item15());
-			alliedNPATProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPProdC_item25());
+			alliedNPATProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPNProdC_item25());
 			alliedNPATProfC.setDirCareCostNonProdHrsOtherBudget(root.getAlliedNPNProdC_item35());
 			alliedNPATProfC.setConfirmationId(root.getForm().getConfirmationId());
 			alliedNPATProfC.setDirCareCostType(root.getAlliedNP_label());
@@ -784,7 +784,7 @@ public class LtcAnnualBudgetApiResponseProcessor implements Processor {
 			alliedNPOTHProfC.setDirCareCostProdHrsOrientationBudget(root.getAlliedNPProdC_item36());
 			alliedNPOTHProfC.setDirCareCostProdHrsContractedBudget(root.getAlliedNPProdCCS6());
 			alliedNPOTHProfC.setDirCareCostNonProdHrsVacBudget(root.getAlliedNPNProdC_item16());
-			alliedNPOTHProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPProdC_item26());
+			alliedNPOTHProfC.setDirCareCostNonProdHrsSickBudget(root.getAlliedNPNProdC_item26());
 			alliedNPOTHProfC.setDirCareCostNonProdHrsOtherBudget(root.getAlliedNPNProdC_item36());
 			alliedNPOTHProfC.setConfirmationId(root.getForm().getConfirmationId());
 			alliedNPOTHProfC.setDirCareCostType(root.getAlliedNP_label());

--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/processor/BaseLtcQuarterlyYtdApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/processor/BaseLtcQuarterlyYtdApiResponseProcessor.java
@@ -3136,7 +3136,7 @@ public abstract class BaseLtcQuarterlyYtdApiResponseProcessor implements Process
 					janYtdOccDays.setConfirmationId(root.getForm().getConfirmationId());
 					janYtdOccDays.setOccDaysYTDInScopePublic(root.getInScopeMonth1());
 					janYtdOccDays.setOccDaysYTOutScopePublic(root.getOutScopeMonth1());
-					janYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth12());
+					janYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth1());
 					janYtdOccDays.setOccMonth("January");
 					janYtdOccDays.setOccQuarter("Q4");
 					janYtdOccDays.setOccDaysYtdTotalDays(root.getTotalMonth1());
@@ -3145,7 +3145,7 @@ public abstract class BaseLtcQuarterlyYtdApiResponseProcessor implements Process
 					febYtdOccDays.setConfirmationId(root.getForm().getConfirmationId());
 					febYtdOccDays.setOccDaysYTDInScopePublic(root.getInScopeMonth2());
 					febYtdOccDays.setOccDaysYTOutScopePublic(root.getOutScopeMonth2());
-					febYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth12());
+					febYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth2());
 					febYtdOccDays.setOccMonth("February");
 					febYtdOccDays.setOccQuarter("Q4");
 					febYtdOccDays.setOccDaysYtdTotalDays(root.getTotalMonth2());
@@ -3154,7 +3154,7 @@ public abstract class BaseLtcQuarterlyYtdApiResponseProcessor implements Process
 					marYtdOccDays.setConfirmationId(root.getForm().getConfirmationId());
 					marYtdOccDays.setOccDaysYTDInScopePublic(root.getInScopeMonth3());
 					marYtdOccDays.setOccDaysYTOutScopePublic(root.getOutScopeMonth3());
-					marYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth12());
+					marYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth3());
 					marYtdOccDays.setOccMonth("March");
 					marYtdOccDays.setOccQuarter("Q4");
 					marYtdOccDays.setOccDaysYtdTotalDays(root.getTotalMonth3());

--- a/src/main/java/ca/bc/gov/chefs/etl/util/CSVUtil.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/util/CSVUtil.java
@@ -120,9 +120,9 @@ public class CSVUtil {
 		if (date.length() == 10) {
 			LocalDateTime dateTime = LocalDate.parse(date).atTime(0, 0);
 			return dateTime.format(outputFormatter);
-		} else if (date.length() == 22) {
+		} else if (date.contains(" ") && (date.endsWith("AM") || date.endsWith("PM"))) {
 			// Handle dates without time zone offset. E.g. 2024-06-30 12:00:00 AM
-			DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss a");
+			DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss a", java.util.Locale.ENGLISH);
 			LocalDateTime dateTime = LocalDateTime.parse(date, inputFormatter);
 			return dateTime.format(outputFormatter);
 		} else {


### PR DESCRIPTION
This pull request addresses several data mapping and date formatting issues in the ETL processing code for Long-Term Care (LTC) budget and quarterly submissions. The main focus is on correcting source field references to ensure accurate data extraction and improving date parsing logic for more robust handling of input formats.

**Key changes include:**

### Data Mapping Corrections

* Updated the mapping for non-productive sick hours budget fields in the `parseAnnualBudgetRequest` method to use the correct `AlliedNPNProdC_itemXX` fields, ensuring that non-productive sick hours are sourced from the appropriate data fields for each professional category (`alliedNPRTProfC`, `alliedNPRAProfC`, `alliedNPAWProfC`, `alliedNPMTProfC`, `alliedNPATProfC`, `alliedNPOTHProfC`). [[1]](diffhunk://#diff-ac6bb2fa3737e487d8a43caa29905324f7c95fdc48e91eb5e467ae0c1e33d887L688-R688) [[2]](diffhunk://#diff-ac6bb2fa3737e487d8a43caa29905324f7c95fdc48e91eb5e467ae0c1e33d887L707-R707) [[3]](diffhunk://#diff-ac6bb2fa3737e487d8a43caa29905324f7c95fdc48e91eb5e467ae0c1e33d887L727-R727) [[4]](diffhunk://#diff-ac6bb2fa3737e487d8a43caa29905324f7c95fdc48e91eb5e467ae0c1e33d887L747-R747) [[5]](diffhunk://#diff-ac6bb2fa3737e487d8a43caa29905324f7c95fdc48e91eb5e467ae0c1e33d887L767-R767) [[6]](diffhunk://#diff-ac6bb2fa3737e487d8a43caa29905324f7c95fdc48e91eb5e467ae0c1e33d887L787-R787)
* Corrected the mapping of private occupancy days for January, February, and March in the `parseYtdQuarterlyRequest` method to use `PrivateMonth1`, `PrivateMonth2`, and `PrivateMonth3` respectively, instead of incorrectly referencing `PrivateMonth12`. [[1]](diffhunk://#diff-8c53ca32d39bc8ab595bfa4fdd55570bc8590840d069a37ffecde7b55b3a7c3dL3139-R3139) [[2]](diffhunk://#diff-8c53ca32d39bc8ab595bfa4fdd55570bc8590840d069a37ffecde7b55b3a7c3dL3148-R3148) [[3]](diffhunk://#diff-8c53ca32d39bc8ab595bfa4fdd55570bc8590840d069a37ffecde7b55b3a7c3dL3157-R3157)

### Date Formatting Improvements

* Enhanced the `formatDate` method in `CSVUtil.java` to more robustly detect and parse date strings that include AM/PM time indicators, and explicitly set the locale to English for parsing, improving reliability for different input formats.
