### PR TITLE
fix: BCMOHAM-29035 missing OCC_DAYS_YTD_TOTAL_DAYS for Q3

### DIFF
--- a/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/processor/BaseLtcQuarterlyYtdApiResponseProcessor.java
+++ b/src/main/java/ca/bc/gov/chefs/etl/forms/ltc/quarterly/processor/BaseLtcQuarterlyYtdApiResponseProcessor.java
@@ -3046,6 +3046,7 @@ public abstract class BaseLtcQuarterlyYtdApiResponseProcessor implements Process
 					octYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth10());
 					octYtdOccDays.setOccMonth("October");
 					octYtdOccDays.setOccQuarter("Q3");
+					octYtdOccDays.setOccDaysYtdTotalDays(root.getTotalMonth10());
 
 					LtcBedYtdOccupiedDays novYtdOccDays = new LtcBedYtdOccupiedDays();
 					novYtdOccDays.setConfirmationId(root.getForm().getConfirmationId());
@@ -3054,6 +3055,7 @@ public abstract class BaseLtcQuarterlyYtdApiResponseProcessor implements Process
 					novYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth11());
 					novYtdOccDays.setOccMonth("November");
 					novYtdOccDays.setOccQuarter("Q3");
+					novYtdOccDays.setOccDaysYtdTotalDays(root.getTotalMonth11());
 
 					LtcBedYtdOccupiedDays decYtdOccDays = new LtcBedYtdOccupiedDays();
 					decYtdOccDays.setConfirmationId(root.getForm().getConfirmationId());
@@ -3062,6 +3064,7 @@ public abstract class BaseLtcQuarterlyYtdApiResponseProcessor implements Process
 					decYtdOccDays.setOccDaysYTDPrivate(root.getPrivateMonth12());
 					decYtdOccDays.setOccMonth("December");
 					decYtdOccDays.setOccQuarter("Q3");
+					decYtdOccDays.setOccDaysYtdTotalDays(root.getTotalMonth12());
 					Collections.addAll(ltcBedYtdOccupiedDays, octYtdOccDays, novYtdOccDays, decYtdOccDays);
 
 					// Q3


### PR DESCRIPTION
- utilized co-pilot to find missing method calls
- method call to setOccDaysYtdTotalDays for October, November, December was missing but present for other quarters
- verified value is added to .txt report file
- verified application builds and can be run